### PR TITLE
Fix: Stonecall is not usable by pawns incapable of violence

### DIFF
--- a/1.4/Defs/Ability_Defs.xml
+++ b/1.4/Defs/Ability_Defs.xml
@@ -81,6 +81,7 @@
     <canUseAoeToGetTargets>false</canUseAoeToGetTargets>
     <jobDef>CastAbilityOnThing</jobDef>
 	<targetRequired>False</targetRequired>
+    <hostile>false</hostile>
     <statBases>
       <Ability_Duration>500</Ability_Duration>
     </statBases>

--- a/1.5/Defs/Ability_Defs.xml
+++ b/1.5/Defs/Ability_Defs.xml
@@ -81,6 +81,8 @@
     <canUseAoeToGetTargets>false</canUseAoeToGetTargets>
     <jobDef>CastAbilityOnThing</jobDef>
 	<targetRequired>False</targetRequired>
+    <hostile>false</hostile>
+    <casterMustBeCapableOfViolence>false</casterMustBeCapableOfViolence>
     <statBases>
       <Ability_Duration>500</Ability_Duration>
     </statBases>


### PR DESCRIPTION
This fixes an issue in RimWorld 1.5 where pawns incapable of violence have the Stonecall ability disabled.

RimWorld 1.5.4062 included a fix to prevent non-violent pawns from using combat abilities, adding a new flag named `casterMustBeCapableOfViolence` which should be `false` for non-combat abilities. This adds it to the ability def for 1.5, as well as setting `hostile` to `false` for the defs in both versions.